### PR TITLE
Workaround for Azure Devops not working with DI for Azure Functions

### DIFF
--- a/Swabbr.AzureFunctions/Directory.Build.targets
+++ b/Swabbr.AzureFunctions/Directory.Build.targets
@@ -1,0 +1,17 @@
+<Project>
+  <PropertyGroup>
+    <_IsFunctionsSdkBuild Condition="$(_FunctionsTaskFramework) != ''">true</_IsFunctionsSdkBuild>
+    <_FunctionsExtensionsDir>$(TargetDir)</_FunctionsExtensionsDir>
+    <_FunctionsExtensionsDir Condition="$(_IsFunctionsSdkBuild) == 'true'">$(_FunctionsExtensionsDir)bin</_FunctionsExtensionsDir>
+  </PropertyGroup>
+
+  <Target Name="CopyExtensionsJson" AfterTargets="_GenerateFunctionsAndCopyContentFiles">
+    <Message Importance="High" Text="Overwritting extensions.json file with one from build." />
+
+    <Copy Condition="$(_IsFunctionsSdkBuild) == 'true' AND Exists('$(_FunctionsExtensionsDir)\extensions.json')"
+          SourceFiles="$(_FunctionsExtensionsDir)\extensions.json"
+          DestinationFiles="$(PublishDir)bin\extensions.json"
+          OverwriteReadOnlyFiles="true"
+          ContinueOnError="true"/>
+  </Target>
+</Project>


### PR DESCRIPTION
Due to DI not working after Azure Devops. See https://github.com/Azure/azure-functions-host/issues/3386 for more details about this workaround.