### PR TITLE
Added encoding

### DIFF
--- a/Swabbr.AzureMediaServices/Clients/AMSClient.cs
+++ b/Swabbr.AzureMediaServices/Clients/AMSClient.cs
@@ -72,6 +72,11 @@ namespace Swabbr.AzureMediaServices.Clients
                     }
                 },
                 VanityUrl = false,
+                Encoding = new LiveEventEncoding
+                {
+                    EncodingType = LiveEventEncodingType.Standard,
+                    PresetName = "Default720p"
+                }
             };
             return await amsClient.LiveEvents.CreateAsync(_config.ResourceGroup, _config.AccountName, liveEventName, liveEventRequest).ConfigureAwait(false);
         }

--- a/Swabbr.AzureMediaServices/Services/AMSLivestreamService.cs
+++ b/Swabbr.AzureMediaServices/Services/AMSLivestreamService.cs
@@ -287,6 +287,7 @@ namespace Swabbr.AzureMediaServices.Services
             // TODO Implement
 
             // External operations
+            // TODO Make transactional
             await _amsClient.StartLiveEventAsync(livestream.ExternalId).ConfigureAwait(false);
             await _amsClient.CreateLiveOutputAsync(vlog.Id, livestream.ExternalId).ConfigureAwait(false);
             await _amsClient.CreateLivestreamVlogStreamingLocatorAsync(vlog.Id, livestream.ExternalId).ConfigureAwait(false);

--- a/Swabbr.Core/Services/VlogTriggerService.cs
+++ b/Swabbr.Core/Services/VlogTriggerService.cs
@@ -78,6 +78,7 @@ namespace Swabbr.Core.Services
                 if (await _livestreamingService.IsUserInLivestreamCycleAsync(userId).ConfigureAwait(false)) { throw new UserAlreadyInLivestreamCycleException(); }
 
                 // Process livestream
+                // TODO This isn't transactional!
                 var livestream = await _livestreamingService.TryClaimLivestreamForUserAsync(userId, triggerMinute).ConfigureAwait(false);
 
                 // Process notifications


### PR DESCRIPTION
Set to default720p. We are now able to connect, and our inconsistency appears to be gone (for now, we shall see). This was done because adding a blank live event to a blank AMS in the Azure Portal forces you to specify the encoding type.