### PR TITLE
Created vlog like functionality according to requirements

### DIFF
--- a/Postman/Swabbr Backend.postman_collection.json
+++ b/Postman/Swabbr Backend.postman_collection.json
@@ -104,7 +104,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"email\": \"testemail2@gmail.com\",\n\t\"nickname\": \"Het andere joch\",\n\t\"password\": \"Welkom01!\",\n\t\"firstName\": \"Jannelien\",\n\t\"lastName\": \"van Steen\",\n\t\"birthDate\": \"09-01-1995\",\n\t\"gender\": \"female\",\n\t\"isPrivate\": \"true\"\n}",
+							"raw": "{\n\t\"email\": \"donnie@gmail.com\",\n\t\"nickname\": \"DonZand2\",\n\t\"password\": \"Welkom01!\",\n\t\"firstName\": \"Don\",\n\t\"lastName\": \"Zandbergen\",\n\t\"birthDate\": \"1996-09-01T00:00:00\",\n\t\"gender\": 1,\n\t\"isPrivate\": false\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -208,14 +208,22 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{apiUrl}}/followrequest/outgoing/06078cd9-49d5-42d5-9e72-60a36f059175",
+							"raw": "{{apiUrl}}/followrequest?requesterId=138cfd2a-1eda-406a-9ef0-4e713c039a32&receiverId=5cb90353-cef0-48f9-b2a2-953d98665017",
 							"host": [
 								"{{apiUrl}}"
 							],
 							"path": [
-								"followrequest",
-								"outgoing",
-								"06078cd9-49d5-42d5-9e72-60a36f059175"
+								"followrequest"
+							],
+							"query": [
+								{
+									"key": "requesterId",
+									"value": "138cfd2a-1eda-406a-9ef0-4e713c039a32"
+								},
+								{
+									"key": "receiverId",
+									"value": "5cb90353-cef0-48f9-b2a2-953d98665017"
+								}
 							]
 						}
 					},
@@ -279,7 +287,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{apiUrl}}/followrequest?receiverId=06078cd9-49d5-42d5-9e72-60a36f059175",
+							"raw": "{{apiUrl}}/followrequest?receiverId=10b5af80-bcf1-4b54-bbf2-fa40eeca47bb",
 							"host": [
 								"{{apiUrl}}"
 							],
@@ -289,7 +297,7 @@
 							"query": [
 								{
 									"key": "receiverId",
-									"value": "06078cd9-49d5-42d5-9e72-60a36f059175"
+									"value": "10b5af80-bcf1-4b54-bbf2-fa40eeca47bb"
 								}
 							]
 						}
@@ -302,14 +310,13 @@
 						"method": "POST",
 						"header": [],
 						"url": {
-							"raw": "{{apiUrl}}/followrequest/unfollow/?receiverId=06078cd9-49d5-42d5-9e72-60a36f059175",
+							"raw": "{{apiUrl}}/followrequest/unfollow?receiverId=06078cd9-49d5-42d5-9e72-60a36f059175",
 							"host": [
 								"{{apiUrl}}"
 							],
 							"path": [
 								"followrequest",
-								"unfollow",
-								""
+								"unfollow"
 							],
 							"query": [
 								{
@@ -332,13 +339,13 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{apiUrl}}/user/06078cd9-49d5-42d5-9e72-60a36f059175",
+							"raw": "{{apiUrl}}/user/138cfd2a-1eda-406a-9ef0-4e713c039a32",
 							"host": [
 								"{{apiUrl}}"
 							],
 							"path": [
 								"user",
-								"06078cd9-49d5-42d5-9e72-60a36f059175"
+								"138cfd2a-1eda-406a-9ef0-4e713c039a32"
 							]
 						}
 					},
@@ -369,13 +376,13 @@
 							}
 						},
 						"url": {
-							"raw": "{{apiUrl}}/user/e29db534-6ecb-428d-a06f-3a495e322767/followers",
+							"raw": "{{apiUrl}}/user/10b5af80-bcf1-4b54-bbf2-fa40eeca47bb/followers",
 							"host": [
 								"{{apiUrl}}"
 							],
 							"path": [
 								"user",
-								"e29db534-6ecb-428d-a06f-3a495e322767",
+								"10b5af80-bcf1-4b54-bbf2-fa40eeca47bb",
 								"followers"
 							]
 						}
@@ -502,7 +509,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{apiUrl}}/user/search?query=het &limit=20&offset=0",
+							"raw": "{{apiUrl}}/user/search?query=men&limit=20&offset=0",
 							"host": [
 								"{{apiUrl}}"
 							],
@@ -513,7 +520,7 @@
 							"query": [
 								{
 									"key": "query",
-									"value": "het "
+									"value": "men"
 								},
 								{
 									"key": "limit",
@@ -560,7 +567,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"firstName\": \"Jeronirokgjhgni\",\n\t\"lastName\": \"Pepperroooooon\",\n\t\"birthDate\": \"09-01-1995\",\n\t\"gender\": \"male\",\n\t\"isPrivate\": \"false\",\n    \"country\": \"NLD\",\n    \"profileImageBase64Encoded\": \"sdkjkhjl\",\n    \"timeZone\": \"1970-01-01T02:00\"\n}",
+							"raw": "{\n\t\"firstName\": \"Jeronirokgjhgni\",\n\t\"lastName\": \"Pepperroooooon\",\n\t\"gender\": 1,\n\t\"isPrivate\": false,\n    \"country\": \"NLD\",\n    \"birthDate\": \"1996-09-01T00:00:00\",\n    \"timeZone\": \"+09:00\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -646,6 +653,43 @@
 					"response": []
 				},
 				{
+					"name": "Get presigned uri",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{apiUrl}}/vlog/generate-upload-uri",
+							"host": [
+								"{{apiUrl}}"
+							],
+							"path": [
+								"vlog",
+								"generate-upload-uri"
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "Get Vlog",
 					"protocolProfileBehavior": {
 						"disableBodyPruning": true
@@ -670,51 +714,13 @@
 							}
 						},
 						"url": {
-							"raw": "{{apiUrl}}/vlog/67b2ad77-0f34-4da6-aba1-9258cf78e3d0",
+							"raw": "{{apiUrl}}/vlog/13ed65e1-9911-439e-be20-d9401f2cacae",
 							"host": [
 								"{{apiUrl}}"
 							],
 							"path": [
 								"vlog",
-								"67b2ad77-0f34-4da6-aba1-9258cf78e3d0"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Get Vlog Like Summary",
-					"protocolProfileBehavior": {
-						"disableBodyPruning": true
-					},
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"name": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n\t\"firstName\": \"THOMAS\",\n\t\"lastName\": \"Benkers\",\n\t\"gender\": \"female\",\n\t\"country\": \"EN\",\n\t\"birthDate\": \"09-01-1995\",\n\t\"timeZone\": \"UTC+01:00\",\n\t\"nickname\": \"Meneer Etli\",\n\t\"profileImageUrl\": \"https://www.w3schools.com/w3css/img_lights.jpg\",\n\t\"isPrivate\": false,\n\t\"phoneNumber\": \"+31629238654\"\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{apiUrl}}/vlog/67b2ad77-0f34-4da6-aba1-9258cf78e3d0/summary",
-							"host": [
-								"{{apiUrl}}"
-							],
-							"path": [
-								"vlog",
-								"67b2ad77-0f34-4da6-aba1-9258cf78e3d0",
-								"summary"
+								"13ed65e1-9911-439e-be20-d9401f2cacae"
 							]
 						}
 					},
@@ -752,44 +758,6 @@
 							"path": [
 								"vlog",
 								"recommended"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Get Vlog Likes",
-					"protocolProfileBehavior": {
-						"disableBodyPruning": true
-					},
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"name": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n\t\"firstName\": \"THOMAS\",\n\t\"lastName\": \"Benkers\",\n\t\"gender\": \"female\",\n\t\"country\": \"EN\",\n\t\"birthDate\": \"09-01-1995\",\n\t\"timeZone\": \"UTC+01:00\",\n\t\"nickname\": \"Meneer Etli\",\n\t\"profileImageUrl\": \"https://www.w3schools.com/w3css/img_lights.jpg\",\n\t\"isPrivate\": false,\n\t\"phoneNumber\": \"+31629238654\"\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{apiUrl}}/vlog/67b2ad77-0f34-4da6-aba1-9258cf78e3d0/likes",
-							"host": [
-								"{{apiUrl}}"
-							],
-							"path": [
-								"vlog",
-								"67b2ad77-0f34-4da6-aba1-9258cf78e3d0",
-								"likes"
 							]
 						}
 					},
@@ -834,41 +802,6 @@
 					"response": []
 				},
 				{
-					"name": "Like Vlog",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"name": "Content-Type",
-								"value": "application/json",
-								"type": "text"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n\t\"firstName\": \"THOMAS\",\n\t\"lastName\": \"Benkers\",\n\t\"gender\": \"female\",\n\t\"country\": \"EN\",\n\t\"birthDate\": \"09-01-1995\",\n\t\"timeZone\": \"UTC+01:00\",\n\t\"nickname\": \"Meneer Etli\",\n\t\"profileImageUrl\": \"https://www.w3schools.com/w3css/img_lights.jpg\",\n\t\"isPrivate\": false,\n\t\"phoneNumber\": \"+31629238654\"\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{apiUrl}}/vlog/67b2ad77-0f34-4da6-aba1-9258cf78e3d0/like",
-							"host": [
-								"{{apiUrl}}"
-							],
-							"path": [
-								"vlog",
-								"67b2ad77-0f34-4da6-aba1-9258cf78e3d0",
-								"like"
-							]
-						}
-					},
-					"response": []
-				},
-				{
 					"name": "Post Vlog",
 					"request": {
 						"method": "POST",
@@ -896,41 +829,6 @@
 							],
 							"path": [
 								"vlog"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Unlike Vlog",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"name": "Content-Type",
-								"value": "application/json",
-								"type": "text"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n\t\"firstName\": \"THOMAS\",\n\t\"lastName\": \"Benkers\",\n\t\"gender\": \"female\",\n\t\"country\": \"EN\",\n\t\"birthDate\": \"09-01-1995\",\n\t\"timeZone\": \"UTC+01:00\",\n\t\"nickname\": \"Meneer Etli\",\n\t\"profileImageUrl\": \"https://www.w3schools.com/w3css/img_lights.jpg\",\n\t\"isPrivate\": false,\n\t\"phoneNumber\": \"+31629238654\"\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{apiUrl}}/vlog/67b2ad77-0f34-4da6-aba1-9258cf78e3d0/unlike",
-							"host": [
-								"{{apiUrl}}"
-							],
-							"path": [
-								"vlog",
-								"67b2ad77-0f34-4da6-aba1-9258cf78e3d0",
-								"unlike"
 							]
 						}
 					},
@@ -965,6 +863,271 @@
 							"path": [
 								"vlog",
 								"2fad77fe-3df8-4cdd-bcd0-e17f92ef2ab7"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Vlog Likes",
+			"item": [
+				{
+					"name": "Exists Vlog Like",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"firstName\": \"THOMAS\",\n\t\"lastName\": \"Benkers\",\n\t\"gender\": \"female\",\n\t\"country\": \"EN\",\n\t\"birthDate\": \"09-01-1995\",\n\t\"timeZone\": \"UTC+01:00\",\n\t\"nickname\": \"Meneer Etli\",\n\t\"profileImageUrl\": \"https://www.w3schools.com/w3css/img_lights.jpg\",\n\t\"isPrivate\": false,\n\t\"phoneNumber\": \"+31629238654\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{apiUrl}}/vlog-like/exists/6ae1734c-0fc5-4f0b-8e09-12a932d825c3/9aa4dc7c-54b9-4a15-953f-329c83d99510",
+							"host": [
+								"{{apiUrl}}"
+							],
+							"path": [
+								"vlog-like",
+								"exists",
+								"6ae1734c-0fc5-4f0b-8e09-12a932d825c3",
+								"9aa4dc7c-54b9-4a15-953f-329c83d99510"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get Vlog Like",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"firstName\": \"THOMAS\",\n\t\"lastName\": \"Benkers\",\n\t\"gender\": \"female\",\n\t\"country\": \"EN\",\n\t\"birthDate\": \"09-01-1995\",\n\t\"timeZone\": \"UTC+01:00\",\n\t\"nickname\": \"Meneer Etli\",\n\t\"profileImageUrl\": \"https://www.w3schools.com/w3css/img_lights.jpg\",\n\t\"isPrivate\": false,\n\t\"phoneNumber\": \"+31629238654\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{apiUrl}}/vlog-like/6ae1734c-0fc5-4f0b-8e09-12a932d825c3/9aa4dc7c-54b9-4a15-953f-329c83d99510",
+							"host": [
+								"{{apiUrl}}"
+							],
+							"path": [
+								"vlog-like",
+								"6ae1734c-0fc5-4f0b-8e09-12a932d825c3",
+								"9aa4dc7c-54b9-4a15-953f-329c83d99510"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get Vlog Like Summary",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"firstName\": \"THOMAS\",\n\t\"lastName\": \"Benkers\",\n\t\"gender\": \"female\",\n\t\"country\": \"EN\",\n\t\"birthDate\": \"09-01-1995\",\n\t\"timeZone\": \"UTC+01:00\",\n\t\"nickname\": \"Meneer Etli\",\n\t\"profileImageUrl\": \"https://www.w3schools.com/w3css/img_lights.jpg\",\n\t\"isPrivate\": false,\n\t\"phoneNumber\": \"+31629238654\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{apiUrl}}/vlog-like/summary/6ae1734c-0fc5-4f0b-8e09-12a932d825c3",
+							"host": [
+								"{{apiUrl}}"
+							],
+							"path": [
+								"vlog-like",
+								"summary",
+								"6ae1734c-0fc5-4f0b-8e09-12a932d825c3"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get Vlog Likes For Vlog",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"firstName\": \"THOMAS\",\n\t\"lastName\": \"Benkers\",\n\t\"gender\": \"female\",\n\t\"country\": \"EN\",\n\t\"birthDate\": \"09-01-1995\",\n\t\"timeZone\": \"UTC+01:00\",\n\t\"nickname\": \"Meneer Etli\",\n\t\"profileImageUrl\": \"https://www.w3schools.com/w3css/img_lights.jpg\",\n\t\"isPrivate\": false,\n\t\"phoneNumber\": \"+31629238654\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{apiUrl}}/vlog-like/for-vlog/6ae1734c-0fc5-4f0b-8e09-12a932d825c3",
+							"host": [
+								"{{apiUrl}}"
+							],
+							"path": [
+								"vlog-like",
+								"for-vlog",
+								"6ae1734c-0fc5-4f0b-8e09-12a932d825c3"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get Vlog Liking Users",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"firstName\": \"THOMAS\",\n\t\"lastName\": \"Benkers\",\n\t\"gender\": \"female\",\n\t\"country\": \"EN\",\n\t\"birthDate\": \"09-01-1995\",\n\t\"timeZone\": \"UTC+01:00\",\n\t\"nickname\": \"Meneer Etli\",\n\t\"profileImageUrl\": \"https://www.w3schools.com/w3css/img_lights.jpg\",\n\t\"isPrivate\": false,\n\t\"phoneNumber\": \"+31629238654\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{apiUrl}}/vlog-like/vlog-liking-users",
+							"host": [
+								"{{apiUrl}}"
+							],
+							"path": [
+								"vlog-like",
+								"vlog-liking-users"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Like Vlog",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"firstName\": \"THOMAS\",\n\t\"lastName\": \"Benkers\",\n\t\"gender\": \"female\",\n\t\"country\": \"EN\",\n\t\"birthDate\": \"09-01-1995\",\n\t\"timeZone\": \"UTC+01:00\",\n\t\"nickname\": \"Meneer Etli\",\n\t\"profileImageUrl\": \"https://www.w3schools.com/w3css/img_lights.jpg\",\n\t\"isPrivate\": false,\n\t\"phoneNumber\": \"+31629238654\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{apiUrl}}/vlog-like/like/6ae1734c-0fc5-4f0b-8e09-12a932d825c3",
+							"host": [
+								"{{apiUrl}}"
+							],
+							"path": [
+								"vlog-like",
+								"like",
+								"6ae1734c-0fc5-4f0b-8e09-12a932d825c3"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Unlike Vlog",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"firstName\": \"THOMAS\",\n\t\"lastName\": \"Benkers\",\n\t\"gender\": \"female\",\n\t\"country\": \"EN\",\n\t\"birthDate\": \"09-01-1995\",\n\t\"timeZone\": \"UTC+01:00\",\n\t\"nickname\": \"Meneer Etli\",\n\t\"profileImageUrl\": \"https://www.w3schools.com/w3css/img_lights.jpg\",\n\t\"isPrivate\": false,\n\t\"phoneNumber\": \"+31629238654\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{apiUrl}}/vlog-like/unlike/6ae1734c-0fc5-4f0b-8e09-12a932d825c3",
+							"host": [
+								"{{apiUrl}}"
+							],
+							"path": [
+								"vlog-like",
+								"unlike",
+								"6ae1734c-0fc5-4f0b-8e09-12a932d825c3"
 							]
 						}
 					},
@@ -1071,14 +1234,20 @@
 							}
 						},
 						"url": {
-							"raw": "{{apiUrl}}/reaction/for-vlog/67b2ad77-0f34-4da6-aba1-9258cf78e3d0",
+							"raw": "{{apiUrl}}/reaction/for-vlog/6ae1734c-0fc5-4f0b-8e09-12a932d825c3?sortingOrder=2",
 							"host": [
 								"{{apiUrl}}"
 							],
 							"path": [
 								"reaction",
 								"for-vlog",
-								"67b2ad77-0f34-4da6-aba1-9258cf78e3d0"
+								"6ae1734c-0fc5-4f0b-8e09-12a932d825c3"
+							],
+							"query": [
+								{
+									"key": "sortingOrder",
+									"value": "2"
+								}
 							]
 						}
 					},
@@ -1137,7 +1306,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"id\": \"8d5cd67c-5317-4895-adeb-85577786aba7\",\n\t\"targetVlogId\": \"a2515bb1-e508-4ca8-92f3-b098af1429d0\",\n\t\"isPrivate\": false\n}",
+							"raw": "{\n    \"id\": \"2ea5607b-977a-4d93-a62d-e8e9c21d9ca6\",\n\t\"targetVlogId\": \"13ed65e1-9911-439e-be20-d9401f2cacae\",\n\t\"isPrivate\": false\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1190,8 +1359,103 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "Get presigned uri Copy",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"firstName\": \"THOMAS\",\n\t\"lastName\": \"Benkers\",\n\t\"gender\": \"female\",\n\t\"country\": \"EN\",\n\t\"birthDate\": \"09-01-1995\",\n\t\"timeZone\": \"UTC+01:00\",\n\t\"nickname\": \"Meneer Etli\",\n\t\"profileImageUrl\": \"https://www.w3schools.com/w3css/img_lights.jpg\",\n\t\"isPrivate\": false,\n\t\"phoneNumber\": \"+31629238654\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{apiUrl}}/reaction/generate-upload-uri",
+							"host": [
+								"{{apiUrl}}"
+							],
+							"path": [
+								"reaction",
+								"generate-upload-uri"
+							]
+						}
+					},
+					"response": []
 				}
 			]
+		},
+		{
+			"name": "Debug",
+			"item": [
+				{
+					"name": "Send Vlog Record Request",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{apiUrl}}/debug/send-request?userId=10b5af80-bcf1-4b54-bbf2-fa40eeca47bb",
+							"host": [
+								"{{apiUrl}}"
+							],
+							"path": [
+								"debug",
+								"send-request"
+							],
+							"query": [
+								{
+									"key": "userId",
+									"value": "10b5af80-bcf1-4b54-bbf2-fa40eeca47bb"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Health",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"currentPassword\": \"Welkom01!\",\n\t\"newPassword\": \"Welkom01!\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{apiUrl}}/health",
+					"host": [
+						"{{apiUrl}}"
+					],
+					"path": [
+						"health"
+					]
+				}
+			},
+			"response": []
 		}
 	],
 	"auth": {
@@ -1230,7 +1494,7 @@
 			"value": ""
 		},
 		{
-			"key": "apiBaseProduction",
+			"key": "apiBaseLocalIIS",
 			"value": ""
 		},
 		{
@@ -1238,7 +1502,17 @@
 			"value": ""
 		},
 		{
+			"key": "apiLocalDocker",
+			"value": ""
+		},
+		{
 			"key": "apiUrl",
+			"value": ""
+		},
+		{
+			"value": ""
+		},
+		{
 			"value": ""
 		}
 	]

--- a/Swabbr.Api/Controllers/VlogController.cs
+++ b/Swabbr.Api/Controllers/VlogController.cs
@@ -106,43 +106,6 @@ namespace Swabbr.Api.Controllers
             // Return.
             return Ok(output);
         }
-
-        // GET: api/vlog/{id}/summary
-        /// <summary>
-        ///     Get a vlog with its likes summarized.
-        /// </summary>
-        /// <param name="vlogId"></param>
-        /// <returns></returns>
-        [HttpGet("{vlogId}/summary")]
-        public async Task<IActionResult> GetWithSummaryAsync([FromRoute] Guid vlogId)
-        {
-            // Act.
-            var vlogLikeSummary = await _vlogService.GetVlogLikeSummaryForVlogAsync(vlogId);
-            
-            // Map.
-            var output = _mapper.Map<VlogLikeSummaryDto>(vlogLikeSummary);
-
-            // Return.
-            return Ok(output);
-        }
-
-        // GET: api/vlog/{id}/likes
-        /// <summary>
-        ///     Get likes for a vlog.
-        /// </summary>
-        /// <returns></returns>
-        [HttpGet("{vlogId}/likes")]
-        public async Task<IActionResult> GetLikesForVlogAsync([FromRoute] Guid vlogId, [FromQuery] PaginationDto pagination)
-        {
-            // Act.
-            var likes = await _vlogService.GetVlogLikesForVlogAsync(vlogId, pagination.ToNavigation()).ToListAsync();
-
-            // Map.
-            var output = _mapper.Map<IEnumerable<VlogLikeDto>>(likes);
-
-            // Return.
-            return Ok(output);
-        }
         
         // GET: api/vlog/recommended
         /// <summary>
@@ -159,20 +122,6 @@ namespace Swabbr.Api.Controllers
 
             // Return.
             return Ok(output);
-        }
-        
-        // POST: api/vlog/{id}/like
-        /// <summary>
-        ///     Like a vlog.
-        /// </summary>
-        [HttpPost("{vlogId}/like")]
-        public async Task<IActionResult> LikeAsync([FromRoute]Guid vlogId)
-        {
-            // Act.
-            await _vlogService.LikeAsync(vlogId);
-
-            // Return.
-            return NoContent();
         }
 
         // GET: api/vlog/for-user/{id}
@@ -208,20 +157,6 @@ namespace Swabbr.Api.Controllers
                 VlogId = input.Id,
             };
             dispatchManager.Dispatch<PostVlogBackgroundTask>(postVlogContext);
-
-            // Return.
-            return NoContent();
-        }
-
-        // POST: api/vlog/{id}/unlike
-        /// <summary>
-        ///     Unlike a vlog.
-        /// </summary>
-        [HttpPost("{vlogId}/unlike")]
-        public async Task<IActionResult> UnlikeAsync([FromRoute]Guid vlogId)
-        {
-            // Act.
-            await _vlogService.UnlikeAsync(vlogId);
 
             // Return.
             return NoContent();

--- a/Swabbr.Api/Controllers/VlogLikeController.cs
+++ b/Swabbr.Api/Controllers/VlogLikeController.cs
@@ -1,0 +1,155 @@
+﻿using AutoMapper;
+using Microsoft.AspNetCore.Mvc;
+using Swabbr.Api.DataTransferObjects;
+using Swabbr.Api.Extensions;
+using Swabbr.Core.Interfaces.Services;
+using Swabbr.Core.Types;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Swabbr.Api.Controllers
+{
+    /// <summary>
+    ///     Controller for handling requests vlog like operations.
+    /// </summary>
+    [ApiController]
+    [Route("vlog-like")]
+    public sealed class VlogLikeController : ControllerBase
+    {
+        private readonly IVlogLikeService _vlogLikeService;
+        private readonly IMapper _mapper;
+
+        /// <summary>
+        ///     Create new instance.
+        /// </summary>
+        public VlogLikeController(IVlogLikeService vlogLikeService,
+            IMapper mapper)
+        {
+            _vlogLikeService = vlogLikeService ?? throw new ArgumentNullException(nameof(vlogLikeService));
+            _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        }
+
+        // GET: api/vlog-like/exits/{vlogId}/{userId}
+        /// <summary>
+        ///     Get a vlog.
+        /// </summary>
+        [HttpGet("exists/{vlogId}/{userId}")]
+        public async Task<IActionResult> ExistsAsync([FromRoute] Guid vlogId, [FromRoute] Guid userId)
+        {
+            // Act.
+            var exists = await _vlogLikeService.ExistsAsync(new VlogLikeId
+            {
+                VlogId = vlogId,
+                UserId = userId
+            });
+
+            // Return.
+            return Ok(exists);
+        }
+
+        // GET: api/vlog-like/{vlogId}/{userId}
+        /// <summary>
+        ///     Get a vlog.
+        /// </summary>
+        [HttpGet("{vlogId}/{userId}")]
+        public async Task<IActionResult> GetAsync([FromRoute] Guid vlogId, [FromRoute] Guid userId)
+        {
+            // Act.
+            var vlogLike = await _vlogLikeService.GetAsync(new VlogLikeId
+            {
+                VlogId = vlogId,
+                UserId = userId
+            });
+
+            // Map.
+            var output = _mapper.Map<VlogLikeDto>(vlogLike);
+
+            // Return.
+            return Ok(output);
+        }
+
+        // GET: api/vlog-like/summary/{id}
+        /// <summary>
+        ///     Get a vlog with its likes summarized.
+        /// </summary>
+        /// <param name="vlogId"></param>
+        /// <returns></returns>
+        [HttpGet("summary/{vlogId}")]
+        public async Task<IActionResult> GetVlogLikeSummaryAsync([FromRoute] Guid vlogId)
+        {
+            // Act.
+            var vlogLikeSummary = await _vlogLikeService.GetVlogLikeSummaryForVlogAsync(vlogId);
+
+            // Map.
+            var output = _mapper.Map<VlogLikeSummaryDto>(vlogLikeSummary);
+
+            // Return.
+            return Ok(output);
+        }
+
+        // GET: api/vlog-like/for-vlog/{vlogId}
+        /// <summary>
+        ///     Get likes for a vlog.
+        /// </summary>
+        /// <returns></returns>
+        [HttpGet("for-vlog/{vlogId}")]
+        public async Task<IActionResult> GetLikesForVlogAsync([FromRoute] Guid vlogId, [FromQuery] PaginationDto pagination)
+        {
+            // Act.
+            var likes = await _vlogLikeService.GetVlogLikesForVlogAsync(vlogId, pagination.ToNavigation()).ToListAsync();
+
+            // Map.
+            var output = _mapper.Map<IEnumerable<VlogLikeDto>>(likes);
+
+            // Return.
+            return Ok(output);
+        }
+
+        // GET: api/vlog-like/vlog-liking-users
+        /// <summary>
+        ///     Get wrappers around all vlog liking users for the current user.
+        /// </summary>
+        [HttpGet("vlog-liking-users")]
+        public async Task<IActionResult> GetVlogLikingUsersAsync([FromQuery] PaginationDto pagination)
+        {
+            // Act.
+            var vlogLikingUserWrappers = await _vlogLikeService.GetVlogLikingUsersForUserAsync(pagination.ToNavigation()).ToListAsync();
+
+            // Map.
+            var output = _mapper.Map<IEnumerable<VlogLikingUserWrapperDto>>(vlogLikingUserWrappers);
+
+            // Return.
+            return Ok(output);
+        }
+
+        // POST: api/vlog-like/like/{vlogId}
+        /// <summary>
+        ///     Like a vlog.
+        /// </summary>
+        [HttpPost("like/{vlogId}")]
+        public async Task<IActionResult> LikeAsync([FromRoute] Guid vlogId)
+        {
+            // Act.
+            await _vlogLikeService.LikeAsync(vlogId);
+
+            // Return.
+            return NoContent();
+        }
+
+        // POST: api/vlog-like/unlike/{vlogId}
+        /// <summary>
+        ///     Unlike a vlog.
+        /// </summary>
+        [HttpPost("unlike/{vlogId}")]
+        public async Task<IActionResult> UnlikeAsync([FromRoute] Guid vlogId)
+        {
+            // Act.
+            await _vlogLikeService.UnlikeAsync(vlogId);
+
+            // Return.
+            return NoContent();
+        }
+    }
+}

--- a/Swabbr.Api/Controllers/VlogLikeController.cs
+++ b/Swabbr.Api/Controllers/VlogLikeController.cs
@@ -51,7 +51,7 @@ namespace Swabbr.Api.Controllers
 
         // GET: api/vlog-like/{vlogId}/{userId}
         /// <summary>
-        ///     Get a vlog.
+        ///     Get a vlog like.
         /// </summary>
         [HttpGet("{vlogId}/{userId}")]
         public async Task<IActionResult> GetAsync([FromRoute] Guid vlogId, [FromRoute] Guid userId)
@@ -72,7 +72,7 @@ namespace Swabbr.Api.Controllers
 
         // GET: api/vlog-like/summary/{id}
         /// <summary>
-        ///     Get a vlog with its likes summarized.
+        ///     Get a summary of the likes for a vlog.
         /// </summary>
         /// <param name="vlogId"></param>
         /// <returns></returns>
@@ -93,7 +93,6 @@ namespace Swabbr.Api.Controllers
         /// <summary>
         ///     Get likes for a vlog.
         /// </summary>
-        /// <returns></returns>
         [HttpGet("for-vlog/{vlogId}")]
         public async Task<IActionResult> GetLikesForVlogAsync([FromRoute] Guid vlogId, [FromQuery] PaginationDto pagination)
         {

--- a/Swabbr.Api/DataTransferObjects/VlogLikingUserWrapperDto.cs
+++ b/Swabbr.Api/DataTransferObjects/VlogLikingUserWrapperDto.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace Swabbr.Api.DataTransferObjects
+{
+    /// <summary>
+    ///     Data class around a user that likes a certain vlog.
+    /// </summary>
+    public record VlogLikingUserWrapperDto
+    {
+        /// <summary>
+        ///     User id of the owner of the liked vlog.
+        /// </summary>
+        public Guid VlogOwnerId { get; set; }
+
+        /// <summary>
+        ///     Indicates if <see cref="VlogOwnerId"/> is 
+        ///     following <see cref="VlogLikingUser"/>.
+        /// </summary>
+        public bool IsVlogOwnerFollowingVlogLikingUser { get; set; }
+
+        /// <summary>
+        ///     Corresponding vlog like entity.
+        /// </summary>
+        public VlogLikeDto VlogLike { get; set; }
+
+        /// <summary>
+        ///     User that liked the vlog.
+        /// </summary>
+        public UserDto VlogLikingUser { get; set; }
+    }
+}

--- a/Swabbr.Api/MapperProfile.cs
+++ b/Swabbr.Api/MapperProfile.cs
@@ -37,6 +37,7 @@ namespace Swabbr.Api
                 .ForMember(dest => dest.UserId, o => o.MapFrom(src => src.Id.UserId))
                 .ForMember(dest => dest.VlogId, o => o.MapFrom(src => src.Id.VlogId));
             mapper.CreateMap<VlogLikeSummary, VlogLikeSummaryDto>();
+            mapper.CreateMap<VlogLikingUserWrapper, VlogLikingUserWrapperDto>();
 
             // Create custom mapping for time zone types
             mapper.CreateMap<TimeZoneInfo, string>().ConvertUsing(tz => tz == null

--- a/Swabbr.Core/Extensions/SwabbrCoreServiceCollectionExtensions.cs
+++ b/Swabbr.Core/Extensions/SwabbrCoreServiceCollectionExtensions.cs
@@ -46,6 +46,7 @@ namespace Swabbr.Core.Extensions
             services.AddScoped<IUserSelectionService, UserSelectionService>();
             services.AddScoped<IReactionService, ReactionService>();
             services.AddScoped<IVlogService, VlogService>();
+            services.AddScoped<IVlogLikeService, VlogLikeService>();
             services.AddScoped<IVlogRequestService, VlogRequestService>();
             services.AddScoped<IUserService, UserService>();
 

--- a/Swabbr.Core/Interfaces/Repositories/IVlogLikeRepository.cs
+++ b/Swabbr.Core/Interfaces/Repositories/IVlogLikeRepository.cs
@@ -27,5 +27,13 @@ namespace Swabbr.Core.Interfaces.Repositories
         /// <param name="vlogId">The vlog to summarize.</param>
         /// <returns>The vlog like summary.</returns>
         Task<VlogLikeSummary> GetSummaryForVlogAsync(Guid vlogId);
+
+        /// <summary>
+        ///     Gets all <see cref="VlogLikingUserWrapper"/> objects that 
+        ///     belong to the vlogs of a given <paramref name="userId"/>.
+        /// </summary>
+        /// <param name="navigation">Result set control.</param>
+        /// <returns>Wrappers around all users that liked saids vlogs.</returns>
+        IAsyncEnumerable<VlogLikingUserWrapper> GetVlogLikingUsersForUserAsync(Navigation navigation);
     }
 }

--- a/Swabbr.Core/Interfaces/Services/IVlogLikeService.cs
+++ b/Swabbr.Core/Interfaces/Services/IVlogLikeService.cs
@@ -1,0 +1,71 @@
+﻿using Swabbr.Core.Entities;
+using Swabbr.Core.Types;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Swabbr.Core.Interfaces.Services
+{
+    /// <summary>
+    ///     Service for processing vlog like operations.
+    /// </summary>
+    /// <remarks>
+    ///     The executing user id is never passed. Whenever 
+    ///     possible, this id is extracted from the context.
+    /// </remarks>
+    public interface IVlogLikeService
+    {
+        /// <summary>
+        ///     Checks if a vlog like exists in our data store.
+        /// </summary>
+        /// <param name="vlogLikeId">The vlog like id to check.</param>
+        Task<bool> ExistsAsync(VlogLikeId vlogLikeId);
+
+        /// <summary>
+        ///     Gets a vlog like from our data store.
+        /// </summary>
+        /// <param name="vlogLikeId">The vlog like id.</param>
+        /// <returns>The vlog like.</returns>
+        Task<VlogLike> GetAsync(VlogLikeId vlogLikeId);
+
+        /// <summary>
+        ///     Gets the likes for a vlog.
+        /// </summary>
+        /// <remarks>
+        ///     This does not scale. If that is required, use an implementation
+        ///     of <see cref="GetVlogLikeSummaryForVlogAsync(Guid)"/> which does
+        ///     not return all vlog likes but only a subset.
+        /// </remarks>
+        /// <param name="vlogId">Internal vlog id</param>
+        /// <param name="navigation">Navigation control.</param>
+        /// <returns>Vlog like collection</returns>
+        IAsyncEnumerable<VlogLike> GetVlogLikesForVlogAsync(Guid vlogId, Navigation navigation);
+
+        /// <summary>
+        ///     Gets all <see cref="VlogLikingUserWrapper"/> objects that 
+        ///     belong to the vlogs of a given <paramref name="userId"/>.
+        /// </summary>
+        /// <param name="navigation">Result set control.</param>
+        /// <returns>Wrappers around all users that liked saids vlogs.</returns>
+        IAsyncEnumerable<VlogLikingUserWrapper> GetVlogLikingUsersForUserAsync(Navigation navigation);
+
+        /// <summary>
+        ///     Gets a like summery for a given vlog.
+        /// </summary>
+        /// <param name="vlogId">Internal vlog id</param>
+        /// <returns>Vlog like summary.</returns>
+        Task<VlogLikeSummary> GetVlogLikeSummaryForVlogAsync(Guid vlogId);
+        
+        /// <summary>
+        ///     Used when the current user likes a vlog.
+        /// </summary>
+        /// <param name="vlogId">The vlog to like.</param>
+        Task LikeAsync(Guid vlogId);
+
+        /// <summary>
+        ///     Used when the current user unlikes a vlog.
+        /// </summary>
+        /// <param name="vlogId">The vlog to unlike.</param>
+        Task UnlikeAsync(Guid vlogId);
+    }
+}

--- a/Swabbr.Core/Interfaces/Services/IVlogService.cs
+++ b/Swabbr.Core/Interfaces/Services/IVlogService.cs
@@ -64,43 +64,11 @@ namespace Swabbr.Core.Interfaces.Services
         IAsyncEnumerable<Vlog> GetVlogsByUserAsync(Guid userId, Navigation navigation);
 
         /// <summary>
-        ///     Gets the likes for a vlog.
-        /// </summary>
-        /// <remarks>
-        ///     This does not scale. If that is required, use an implementation
-        ///     of <see cref="GetVlogLikeSummaryForVlogAsync(Guid)"/> which does
-        ///     not return all vlog likes but only a subset.
-        /// </remarks>
-        /// <param name="vlogId">Internal vlog id</param>
-        /// <param name="navigation">Navigation control.</param>
-        /// <returns>Vlog like collection</returns>
-        IAsyncEnumerable<VlogLike> GetVlogLikesForVlogAsync(Guid vlogId, Navigation navigation);
-
-        /// <summary>
-        ///     Gets a like summery for a given vlog.
-        /// </summary>
-        /// <param name="vlogId">Internal vlog id</param>
-        /// <returns>Vlog like summary.</returns>
-        Task<VlogLikeSummary> GetVlogLikeSummaryForVlogAsync(Guid vlogId);
-        
-        /// <summary>
-        ///     Used when the current user likes a vlog.
-        /// </summary>
-        /// <param name="vlogId">The vlog to like.</param>
-        Task LikeAsync(Guid vlogId);
-
-        /// <summary>
         ///     Called when a vlog has been uploaded to the blob 
         ///     storage and the user wishes to publish it.
         /// </summary>
         /// <param name="context">Context for posting a vlog.</param>
         Task PostVlogAsync(PostVlogContext context);
-
-        /// <summary>
-        ///     Used when the current user unlikes a vlog.
-        /// </summary>
-        /// <param name="vlogId">The vlog to unlike.</param>
-        Task UnlikeAsync(Guid vlogId);
 
         /// <summary>
         ///     Updates a vlog in our data store.

--- a/Swabbr.Core/Services/VlogLikeService.cs
+++ b/Swabbr.Core/Services/VlogLikeService.cs
@@ -1,0 +1,120 @@
+﻿using Swabbr.Core.Abstractions;
+using Swabbr.Core.Entities;
+using Swabbr.Core.Interfaces.Repositories;
+using Swabbr.Core.Interfaces.Services;
+using Swabbr.Core.Types;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Swabbr.Core.Services
+{
+    /// <summary>
+    ///     Service that handles all vlog like related operations.
+    /// </summary>
+    public class VlogLikeService : AppServiceBase, IVlogLikeService
+    {
+        private readonly IVlogRepository _vlogRepository;
+        private readonly IVlogLikeRepository _vlogLikeRepository;
+        private readonly INotificationService _notificationService;
+
+        /// <summary>
+        ///     Create new instance.
+        /// </summary>
+        public VlogLikeService(AppContext appContext,
+            IVlogRepository vlogRepository,
+            IVlogLikeRepository vlogLikeRepository,
+            INotificationService notificationService)
+        {
+            AppContext = appContext ?? throw new ArgumentNullException(nameof(appContext));
+            _vlogRepository = vlogRepository ?? throw new ArgumentNullException(nameof(vlogRepository));
+            _vlogLikeRepository = vlogLikeRepository ?? throw new ArgumentNullException(nameof(vlogLikeRepository));
+            _notificationService = notificationService ?? throw new ArgumentNullException(nameof(notificationService));
+        }
+
+        /// <summary>
+        ///     Checks if a vlog like exists in our data store.
+        /// </summary>
+        /// <param name="vlogLikeId">The vlog like id to check.</param>
+        public Task<bool> ExistsAsync(VlogLikeId vlogLikeId)
+            => _vlogLikeRepository.ExistsAsync(vlogLikeId);
+
+        /// <summary>
+        ///     Gets a vlog like from our data store.
+        /// </summary>
+        /// <param name="vlogLikeId">The vlog like id.</param>
+        /// <returns>The vlog like.</returns>
+        public Task<VlogLike> GetAsync(VlogLikeId vlogLikeId)
+            => _vlogLikeRepository.GetAsync(vlogLikeId);
+
+        /// <summary>
+        ///     Gets all the <see cref="VlogLike"/>s for a <see cref="Vlog"/>.
+        /// </summary>
+        /// <remarks>
+        ///     This does not scale. If that is required, use an implementation
+        ///     of <see cref="GetVlogLikeSummaryForVlogAsync(Guid)"/> which does
+        ///     not return all <see cref="VlogLike"/> but only a subset.
+        /// </remarks>
+        /// <param name="vlogId">Internal <see cref="Vlog"/> id</param>
+        /// <param name="navigation">Navigation control.</param>
+        /// <returns><see cref="VlogLike"/> collection</returns>
+        public IAsyncEnumerable<VlogLike> GetVlogLikesForVlogAsync(Guid vlogId, Navigation navigation)
+            => _vlogLikeRepository.GetForVlogAsync(vlogId, navigation);
+
+        /// <summary>
+        ///     Gets a <see cref="VlogLikeSummary"/> for a given vlog.
+        /// </summary>
+        /// <remarks>
+        ///     The <see cref="VlogLikeSummary.Users"/> does not need
+        ///     to contain all the <see cref="User"/> users.
+        /// </remarks>
+        /// <param name="vlogId">Internal <see cref="Vlog"/> id</param>
+        /// <returns><see cref="VlogLikeSummary"/></returns>
+        public Task<VlogLikeSummary> GetVlogLikeSummaryForVlogAsync(Guid vlogId)
+            => _vlogLikeRepository.GetSummaryForVlogAsync(vlogId);
+
+        /// <summary>
+        ///     Gets all <see cref="VlogLikingUserWrapper"/> objects that 
+        ///     belong to the vlogs of a given <paramref name="userId"/>.
+        /// </summary>
+        /// <remarks>
+        ///     The user id is extracted from the <see cref="AppContext"/>.
+        /// </remarks>
+        /// <param name="navigation">Result set control.</param>
+        /// <returns>Wrappers around all users that liked saids vlogs.</returns>
+        public IAsyncEnumerable<VlogLikingUserWrapper> GetVlogLikingUsersForUserAsync(Navigation navigation)
+            => _vlogLikeRepository.GetVlogLikingUsersForUserAsync(navigation);
+
+        /// <summary>
+        ///     Used when the current users like a vlog. This also
+        ///     dispatches a notification to the vlog owner.
+        /// </summary>
+        /// <param name="vlogId">The vlog to like.</param>
+        public async Task LikeAsync(Guid vlogId)
+        {
+            var vlogLikeId = await _vlogLikeRepository.CreateAsync(new VlogLike
+            {
+                Id = new VlogLikeId
+                {
+                    UserId = AppContext.UserId,
+                    VlogId = vlogId
+                }
+            });
+
+            var vlog = await _vlogRepository.GetAsync(vlogId);
+
+            await _notificationService.NotifyVlogLikedAsync(vlog.UserId, vlogLikeId);
+        }
+
+        /// <summary>
+        ///     Used when the current user unlikes a vlog.
+        /// </summary>
+        /// <param name="vlogId">The vlog to unlike.</param>
+        public Task UnlikeAsync(Guid vlogId)
+            => _vlogLikeRepository.DeleteAsync(new VlogLikeId
+            {
+                VlogId = vlogId,
+                UserId = AppContext.UserId
+            });
+    }
+}

--- a/Swabbr.Core/Services/VlogService.cs
+++ b/Swabbr.Core/Services/VlogService.cs
@@ -137,52 +137,6 @@ namespace Swabbr.Core.Services
         }
 
         /// <summary>
-        ///     Gets all the <see cref="VlogLike"/>s for a <see cref="Vlog"/>.
-        /// </summary>
-        /// <remarks>
-        ///     This does not scale. If that is required, use an implementation
-        ///     of <see cref="GetVlogLikeSummaryForVlogAsync(Guid)"/> which does
-        ///     not return all <see cref="VlogLike"/> but only a subset.
-        /// </remarks>
-        /// <param name="vlogId">Internal <see cref="Vlog"/> id</param>
-        /// <param name="navigation">Navigation control.</param>
-        /// <returns><see cref="VlogLike"/> collection</returns>
-        public IAsyncEnumerable<VlogLike> GetVlogLikesForVlogAsync(Guid vlogId, Navigation navigation)
-            => _vlogLikeRepository.GetForVlogAsync(vlogId, navigation);
-
-        /// <summary>
-        ///     Gets a <see cref="VlogLikeSummary"/> for a given vlog.
-        /// </summary>
-        /// <remarks>
-        ///     The <see cref="VlogLikeSummary.Users"/> does not need
-        ///     to contain all the <see cref="User"/> users.
-        /// </remarks>
-        /// <param name="vlogId">Internal <see cref="Vlog"/> id</param>
-        /// <returns><see cref="VlogLikeSummary"/></returns>
-        public Task<VlogLikeSummary> GetVlogLikeSummaryForVlogAsync(Guid vlogId)
-            => _vlogLikeRepository.GetSummaryForVlogAsync(vlogId);
-
-        /// <summary>
-        ///     Used when the current users like a vlog.
-        /// </summary>
-        /// <param name="vlogId">The vlog to like.</param>
-        public async Task LikeAsync(Guid vlogId)
-        {
-            var vlogLikeId = await _vlogLikeRepository.CreateAsync(new VlogLike
-            {
-                Id = new VlogLikeId
-                {
-                    UserId = AppContext.UserId,
-                    VlogId = vlogId
-                }
-            });
-
-            var vlog = await GetAsync(vlogId);
-
-            await _notificationService.NotifyVlogLikedAsync(vlog.UserId, vlogLikeId);
-        }
-
-        /// <summary>
         ///     Called when a vlog has been uploaded. This will
         ///     publish the vlog and notify all followers.
         /// </summary>
@@ -225,17 +179,6 @@ namespace Swabbr.Core.Services
             // This function will dispatch a notification for each follower.
             await _notificationService.NotifyFollowersVlogPostedAsync(AppContext.UserId, context.VlogId);
         }
-
-        /// <summary>
-        ///     Used when the current user unlikes a vlog.
-        /// </summary>
-        /// <param name="vlogId">The vlog to unlike.</param>
-        public Task UnlikeAsync(Guid vlogId)
-            => _vlogLikeRepository.DeleteAsync(new VlogLikeId
-            {
-                VlogId = vlogId,
-                UserId = AppContext.UserId
-            });
 
         /// <summary>
         ///     Updates a vlog in our data store.

--- a/Swabbr.Core/Types/VlogLikingUserWrapper.cs
+++ b/Swabbr.Core/Types/VlogLikingUserWrapper.cs
@@ -1,0 +1,32 @@
+﻿using Swabbr.Core.Entities;
+using System;
+
+namespace Swabbr.Core.Types
+{
+    /// <summary>
+    ///     Data class around a user that likes a certain vlog.
+    /// </summary>
+    public record VlogLikingUserWrapper
+    {
+        /// <summary>
+        ///     User id of the owner of the liked vlog.
+        /// </summary>
+        public Guid VlogOwnerId { get; set; }
+
+        /// <summary>
+        ///     Indicates if <see cref="VlogOwnerId"/> is 
+        ///     following <see cref="VlogLikingUser"/>.
+        /// </summary>
+        public bool IsVlogOwnerFollowingVlogLikingUser { get; set; }
+
+        /// <summary>
+        ///     Corresponding vlog like entity.
+        /// </summary>
+        public VlogLike VlogLike { get; set; }
+
+        /// <summary>
+        ///     User that liked the vlog.
+        /// </summary>
+        public User VlogLikingUser { get; set; }
+    }
+}

--- a/Swabbr.Testing/Repositories/TestVlogLikeRepository.cs
+++ b/Swabbr.Testing/Repositories/TestVlogLikeRepository.cs
@@ -19,5 +19,6 @@ namespace Swabbr.Testing.Repositories
         public Task<VlogLike> GetAsync(VlogLikeId id) => throw new NotImplementedException();
         public IAsyncEnumerable<VlogLike> GetForVlogAsync(Guid vlogId, Navigation navigation) => throw new NotImplementedException();
         public Task<VlogLikeSummary> GetSummaryForVlogAsync(Guid vlogId) => throw new NotImplementedException();
+        public IAsyncEnumerable<VlogLikingUserWrapper> GetVlogLikingUsersForUserAsync(Navigation navigation) => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
This PR introduces functionality for the requirements with regards to the vlog likes. It adds a separate `api/vlog-like` endpoint for vlog likes and additional functionality for these entities. Note that any old vlog-like endpoints were positioned in the `api/vlog` endpoint. All this functionality still exists but has simply been moved to the `api/vlog-like` endpoint. This will be a breaking change for the current application build, but this will soon be updated.

Fixes #236 
Fixes #235 